### PR TITLE
support for newer node versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
 "use strict";
 
 var crypto = require('crypto');
-var setFunctionName = require('function-name');
 var setPrototypeOf = require('setprototypeof');
+
+function setFunctionName (fn, name) {
+  var descriptor = Object.getOwnPropertyDescriptor(fn, 'name');
+  descriptor.value = name;
+  Object.defineProperty(fn, 'name', descriptor);
+};
 
 module.exports = exports = createFunctionInstance;
 var invoke = exports.invoke = require('./invoke');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "function-class",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Easy `Function` subclasses",
   "main": "index.js",
   "scripts": {
@@ -28,8 +28,7 @@
   },
   "homepage": "https://github.com/TooTallNate/node-function-class#readme",
   "dependencies": {
-    "es6-symbol": "^3.0.2",
-    "function-name": "^1.0.0",
-    "setprototypeof": "^1.0.0"
+    "es6-symbol": "^3.1.1",
+    "setprototypeof": "^1.1.1"
   }
 }

--- a/package.noon
+++ b/package.noon
@@ -1,0 +1,27 @@
+name          function-class
+version       1.2.0
+description   Easy `Function` subclasses
+main          index.js
+scripts
+              test  node test
+repository
+              type  git
+              url   git://github.com/TooTallNate/node-function-class.git
+keywords
+              function
+              create
+              name
+              arity
+              length
+              instance
+              subclass
+              prototype
+              inheritance
+author        Nathan Rajlich <n@n8.io>
+license       MIT
+bugs
+              url  https://github.com/TooTallNate/node-function-class/issues
+homepage      https://github.com/TooTallNate/node-function-class#readme
+dependencies
+              es6-symbol      ^3.1.1
+              setprototypeof  ^1.1.1


### PR DESCRIPTION
- removed function-name dependency (doesn't build on newer node versions)
- upgraded remaining dependencies
- added .gitignore and package.noon (optional)

These changes were made in an attempt to get the NodeObjC module to work on never node version under Mojave. 